### PR TITLE
grid_map: move GridMap to own module

### DIFF
--- a/src/terrain_nav_py/dubins_airplane.py
+++ b/src/terrain_nav_py/dubins_airplane.py
@@ -1377,7 +1377,6 @@ class DubinsAirplaneStateSpace(ob.CompoundStateSpace):
             classification = self.classifyPath(alpha, beta)
             # path.setClassification(classification)
 
-
             if self._enable_classification:
                 long_path_case = d > (
                     math.sqrt(4.0 - math.pow(ca + cb, 2.0))
@@ -1439,7 +1438,9 @@ class DubinsAirplaneStateSpace(ob.CompoundStateSpace):
         # classification = path.getClassification()
         if classification == DubinsPath.Classification.CLASS_A11:
             # class a_11: optimal path is RSL
-            path = DubinsAirplaneStateSpace.dubinsRSL_fast(d, alpha, beta, sa, sb, ca, cb)
+            path = DubinsAirplaneStateSpace.dubinsRSL_fast(
+                d, alpha, beta, sa, sb, ca, cb
+            )
         elif classification == DubinsPath.Classification.CLASS_A12:
             # class a_12: depending on S_12, optimal path is either RSR (S_12<0) or RSL (S_12>0)
             if (
@@ -1616,7 +1617,9 @@ class DubinsAirplaneStateSpace(ob.CompoundStateSpace):
         elif (
             classification == DubinsPath.Classification.CLASS_A23
         ):  # class a_23: RSR is optimal
-            path = DubinsAirplaneStateSpace.dubinsRSR_fast(d, alpha, beta, sa, sb, ca, cb)
+            path = DubinsAirplaneStateSpace.dubinsRSR_fast(
+                d, alpha, beta, sa, sb, ca, cb
+            )
         elif classification == DubinsPath.Classification.CLASS_A24:
             # class a_24: depending on S_24, optimal path is RSR (S_24<0) or RSL (S_24>0)
             if (
@@ -1650,7 +1653,9 @@ class DubinsAirplaneStateSpace(ob.CompoundStateSpace):
                 )
         elif classification == DubinsPath.Classification.CLASS_A32:
             # class a_32 (top. equiv. to a_32): optimal path is LSL
-            path = DubinsAirplaneStateSpace.dubinsLSL_fast(d, alpha, beta, sa, sb, ca, cb)
+            path = DubinsAirplaneStateSpace.dubinsLSL_fast(
+                d, alpha, beta, sa, sb, ca, cb
+            )
         elif classification == DubinsPath.Classification.CLASS_A33:
             # class a_33 (top. equiv. to a_33): depending on a, b, S^{1,2}_33,
             # optimal path is  RSR (alpha<beta && S^1_33<0) or LSR (alpha>beta && S^1_33>0)
@@ -1827,7 +1832,9 @@ class DubinsAirplaneStateSpace(ob.CompoundStateSpace):
                     )
         elif classification == DubinsPath.Classification.CLASS_A44:
             # class a_44: optimal path is LSR
-            path = DubinsAirplaneStateSpace.dubinsLSR_fast(d, alpha, beta, sa, sb, ca, cb)
+            path = DubinsAirplaneStateSpace.dubinsLSR_fast(
+                d, alpha, beta, sa, sb, ca, cb
+            )
         else:
             raise RuntimeError(
                 f"default (a not in set{0,1,...,15}), path.a: {path.getClassification()} ,d: {d}"

--- a/src/terrain_nav_py/dubins_path.py
+++ b/src/terrain_nav_py/dubins_path.py
@@ -42,7 +42,6 @@ Data structures used by the DubinsAirPlane model.
 import math
 
 from enum import IntEnum
-from typing import Self
 
 
 class DubinsPath:

--- a/src/terrain_nav_py/grid_map.py
+++ b/src/terrain_nav_py/grid_map.py
@@ -1,0 +1,108 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2025, Rhys Mainwaring
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+GridMap
+"""
+
+import copy
+
+
+# Mock interface for GridMap
+class GridMap:
+
+    class Index:
+        def __init__(self):
+            self.value = 0
+
+    class Iterator:
+        def __init__(self, map):
+            self._start = GridMap.Index()
+            self._index = GridMap.Index()
+            self._size = map.size()
+            self._is_past_end = False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            current = copy.deepcopy(self._index)
+
+            if self._index.value == self._size:
+                self._is_past_end = True
+
+            if not self._is_past_end:
+                self._index.value += 1
+            else:
+                raise StopIteration
+
+            return current
+
+    def __init__(self):
+        self._position = (0.0, 0.0)
+        self._length = (1000.0, 1000.0)
+        self._elevation = 0.0
+        self._distance_surface = 0.0
+        self._max_elevation = 120.0
+        self._size = 10
+
+    def __iter__(self) -> Iterator:
+        return GridMap.Iterator(self)
+
+    def size(self) -> int:
+        return self._size
+
+    def getPosition(self) -> tuple[float, float]:
+        return self._position
+
+    def getLength(self) -> tuple[float, float]:
+        return self._length
+
+    def isInside(self, position: tuple[float, float]) -> bool:
+        return True
+
+    def atPosition(self, layer: str, position: tuple[float, float]) -> float:
+        if layer == "elevation":
+            return self._elevation
+        elif layer == "distance_surface":
+            return self._distance_surface
+        elif layer == "max_elevation":
+            return self._max_elevation
+        else:
+            return float("nan")
+
+    def at(self, layer: str, index: Index) -> float:
+        if layer == "elevation":
+            return self._elevation
+        elif layer == "distance_surface":
+            return self._distance_surface
+        elif layer == "max_elevation":
+            return self._max_elevation
+        else:
+            return float("nan")

--- a/src/terrain_nav_py/ompl_setup.py
+++ b/src/terrain_nav_py/ompl_setup.py
@@ -38,12 +38,12 @@ Terrain planner OMPL setup
 """
 
 from enum import IntEnum
-from typing import Self
 
 from ompl import base as ob
 from ompl import geometric as og
 
-from terrain_nav_py.terrain_ompl import GridMap
+from terrain_nav_py.grid_map import GridMap
+
 from terrain_nav_py.terrain_ompl import TerrainValidityChecker
 
 

--- a/src/terrain_nav_py/path_segment.py
+++ b/src/terrain_nav_py/path_segment.py
@@ -38,7 +38,6 @@ Generate paths for guided path navigation
 """
 
 import math
-from typing import Self
 
 # Use spatial objects defined in pymavlink
 from pymavlink.quaternion import Quaternion

--- a/src/terrain_nav_py/terrain_map.py
+++ b/src/terrain_nav_py/terrain_map.py
@@ -1,0 +1,46 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2025, Rhys Mainwaring
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+TerrainMap
+"""
+
+from terrain_nav_py.grid_map import GridMap
+
+
+# Mock interface for TerrainMap
+class TerrainMap:
+    def __init__(self):
+        self._grid_map = GridMap()
+
+    def getGridMap(self) -> GridMap:
+        return self._grid_map
+
+    def setGridMap(self, map: GridMap) -> None:
+        self._grid_map = map

--- a/src/terrain_nav_py/terrain_ompl.py
+++ b/src/terrain_nav_py/terrain_ompl.py
@@ -37,88 +37,13 @@
 Terrain planner state validity checker and sampler
 """
 
-import copy
 import math
-import sys
 
 from ompl import base as ob
 from ompl import util as ou
 
 from terrain_nav_py.dubins_airplane import DubinsAirplaneStateSpace
-
-
-# Mock interface for GridMap
-class GridMap:
-
-    class Index:
-        def __init__(self):
-            self.value = 0
-
-    class Iterator:
-        def __init__(self, map):
-            self._start = GridMap.Index()
-            self._index = GridMap.Index()
-            self._size = map.size()
-            self._is_past_end = False
-
-        def __iter__(self):
-            return self
-
-        def __next__(self):
-            current = copy.deepcopy(self._index)
-
-            if self._index.value == self._size:
-                self._is_past_end = True
-
-            if not self._is_past_end:
-                self._index.value += 1
-            else:
-                raise StopIteration
-
-            return current
-
-    def __init__(self):
-        self._position = (0.0, 0.0)
-        self._length = (1000.0, 1000.0)
-        self._elevation = 0.0
-        self._distance_surface = 0.0
-        self._max_elevation = 120.0
-        self._size = 10
-
-    def __iter__(self):
-        return GridMap.Iterator(self)
-
-    def size(self):
-        return self._size
-
-    def getPosition(self) -> tuple[float, float]:
-        return self._position
-
-    def getLength(self) -> tuple[float, float]:
-        return self._length
-
-    def isInside(self, position: tuple[float, float]) -> bool:
-        return True
-
-    def atPosition(self, layer: str, position: tuple[float, float]) -> float:
-        if layer == "elevation":
-            return self._elevation
-        elif layer == "distance_surface":
-            return self._distance_surface
-        elif layer == "max_elevation":
-            return self._max_elevation
-        else:
-            return float("nan")
-
-    def at(self, layer: str, index: Index) -> float:
-        if layer == "elevation":
-            return self._elevation
-        elif layer == "distance_surface":
-            return self._distance_surface
-        elif layer == "max_elevation":
-            return self._max_elevation
-        else:
-            return float("nan")
+from terrain_nav_py.grid_map import GridMap
 
 
 class TerrainValidityChecker(ob.StateValidityChecker):

--- a/src/terrain_nav_py/terrain_ompl_rrt.py
+++ b/src/terrain_nav_py/terrain_ompl_rrt.py
@@ -48,29 +48,19 @@ from ompl import geometric as og
 from terrain_nav_py.dubins_airplane import DubinsAirplaneStateSpace
 from terrain_nav_py.dubins_path import DubinsPath
 
+from terrain_nav_py.grid_map import GridMap
+
+from terrain_nav_py.ompl_setup import OmplSetup
+
 from terrain_nav_py import path_segment
 from terrain_nav_py.path_segment import wrap_pi
-from terrain_nav_py.path_segment import wrap_2pi
 
 from terrain_nav_py.path import Path
 from terrain_nav_py.path import PathSegment
 
-from terrain_nav_py.ompl_setup import OmplSetup
+from terrain_nav_py.terrain_map import TerrainMap
 
-from terrain_nav_py.terrain_ompl import GridMap
 from terrain_nav_py.terrain_ompl import TerrainStateSampler
-
-
-# Mock interface for TerrainMap
-class TerrainMap:
-    def __init__(self):
-        self._grid_map = GridMap()
-
-    def getGridMap(self) -> GridMap:
-        return self._grid_map
-
-    def setGridMap(self, map: GridMap) -> None:
-        self._grid_map = map
 
 
 class TerrainOmplRrt:

--- a/tests/test_dubins_airplane.py
+++ b/tests/test_dubins_airplane.py
@@ -28,7 +28,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import math
-import pytest
 
 from ompl import base as ob
 from ompl import geometric as og

--- a/tests/test_dubins_path.py
+++ b/tests/test_dubins_path.py
@@ -28,7 +28,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import math
-import pytest
 
 from terrain_nav_py.dubins_path import DubinsPath
 

--- a/tests/test_ompl_setup.py
+++ b/tests/test_ompl_setup.py
@@ -27,15 +27,12 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import math
-import pytest
-
 from terrain_nav_py.dubins_airplane import DubinsAirplaneStateSpace
 
-from terrain_nav_py.ompl_setup import OmplSetup
+from terrain_nav_py.grid_map import GridMap
 
+from terrain_nav_py.ompl_setup import OmplSetup
 from terrain_nav_py.ompl_setup import PlannerType
-from terrain_nav_py.terrain_ompl import GridMap
 
 
 def test_ompl_setup_planner_type():

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -27,9 +27,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import math
-import pytest
-
 from pymavlink import quaternion
 from pymavlink.rotmat import Matrix3
 from pymavlink.rotmat import Vector3

--- a/tests/test_terrain_ompl.py
+++ b/tests/test_terrain_ompl.py
@@ -27,16 +27,13 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import math
-import pytest
-import sys
-
 from ompl import base as ob
 from ompl import geometric as og
 
 from terrain_nav_py.dubins_airplane import DubinsAirplaneStateSpace
 
-from terrain_nav_py.terrain_ompl import GridMap
+from terrain_nav_py.grid_map import GridMap
+
 from terrain_nav_py.terrain_ompl import TerrainValidityChecker
 from terrain_nav_py.terrain_ompl import TerrainStateSampler
 

--- a/tests/test_terrain_ompl_rrt.py
+++ b/tests/test_terrain_ompl_rrt.py
@@ -28,21 +28,15 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import math
-import pytest
-import sys
-
-from ompl import base as ob
-from ompl import geometric as og
-
 
 from terrain_nav_py.dubins_airplane import DubinsAirplaneStateSpace
 
-from terrain_nav_py.path_segment import PathSegment
+from terrain_nav_py.grid_map import GridMap
+
 from terrain_nav_py.path import Path
 
-from terrain_nav_py.terrain_ompl import GridMap
+from terrain_nav_py.terrain_map import TerrainMap
 
-from terrain_nav_py.terrain_ompl_rrt import TerrainMap
 from terrain_nav_py.terrain_ompl_rrt import TerrainOmplRrt
 
 


### PR DESCRIPTION
Move the GridMap and TerrainMap classes to their own module. These are currently mock-ups that provide a minimal interface.