### PR TITLE
terrain_ompl_rrt: add path plots

### DIFF
--- a/tests/test_terrain_ompl_rrt.py
+++ b/tests/test_terrain_ompl_rrt.py
@@ -77,23 +77,23 @@ def test_terrain_ompl_rrt():
     # planner_solution_path = Path()
     # planner.Solve(time_budget=1.0, path=planner_solution_path)
 
-    # solution path - og.PathGeometric
-    solution_path = planner._problem_setup.getSolutionPath()
-    state1 = solution_path.getState(0)
-    state2 = solution_path.getState(solution_path.getStateCount() - 1)
-    states = solution_path.getStates()
-    pos1 = TerrainOmplRrt.dubinsairplanePosition(state1)
-    yaw1 = TerrainOmplRrt.dubinsairplaneYaw(state1)
-    pos2 = TerrainOmplRrt.dubinsairplanePosition(state2)
-    yaw2 = TerrainOmplRrt.dubinsairplaneYaw(state2)
-    print(f"Planner solution path (og.PathGeometric)")
-    # print(type(solution_path))
-    print(f"path length: {solution_path.length():.2f}")
-    print(f"pos1: {pos1}, yaw1: {yaw1}")
-    print(f"pos2: {pos2}, yaw2: {yaw2}")
-
-    # plots
-    plot_path(start_pos, goal_pos, loiter_radius, candidate_path, states)
+    # only display plots if run as script
+    if __name__ == "__main__":
+        # solution path - og.PathGeometric
+        solution_path = planner._problem_setup.getSolutionPath()
+        state1 = solution_path.getState(0)
+        state2 = solution_path.getState(solution_path.getStateCount() - 1)
+        states = solution_path.getStates()
+        pos1 = TerrainOmplRrt.dubinsairplanePosition(state1)
+        yaw1 = TerrainOmplRrt.dubinsairplaneYaw(state1)
+        pos2 = TerrainOmplRrt.dubinsairplanePosition(state2)
+        yaw2 = TerrainOmplRrt.dubinsairplaneYaw(state2)
+        print(f"Planner solution path (og.PathGeometric)")
+        # print(type(solution_path))
+        print(f"path length: {solution_path.length():.2f}")
+        print(f"pos1: {pos1}, yaw1: {yaw1}")
+        print(f"pos2: {pos2}, yaw2: {yaw2}")
+        plot_path(start_pos, goal_pos, loiter_radius, candidate_path, states)
 
 
 def plot_path(start_pos, goal_pos, loiter_radius, path=None, states=None):

--- a/tests/test_terrain_ompl_rrt.py
+++ b/tests/test_terrain_ompl_rrt.py
@@ -47,7 +47,7 @@ def test_terrain_ompl_rrt():
     terrain_map.setGridMap(grid_map)
 
     # create planner
-    da_space = DubinsAirplaneStateSpace(turningRadius=20.0, gam=0.15)
+    da_space = DubinsAirplaneStateSpace(turningRadius=40.0, gam=0.06)
     planner = TerrainOmplRrt(da_space)
     planner.setMap(terrain_map)
     planner.setAltitudeLimits(max_altitude=120.0, min_altitude=50.0)
@@ -55,13 +55,13 @@ def test_terrain_ompl_rrt():
     # initialise from map
     start_pos = (10.0, 20.0, 60.0)
     goal_pos = (200.0, 400.0, 100.0)
-    start_loiter_radius = 20.0
+    loiter_radius = 40.0
     planner.setBoundsFromMap(terrain_map.getGridMap())
 
     # PLANNER_MODE.GLOBAL
     # set up problem from start and goal positions and start loiter radius
     print("PLANNER_MODE.GLOBAL")
-    planner.setupProblem2(start_pos, goal_pos, start_loiter_radius)
+    planner.setupProblem2(start_pos, goal_pos, loiter_radius)
     candidate_path = Path()
     planner.Solve1(time_budget=1.0, path=candidate_path)
 
@@ -76,6 +76,81 @@ def test_terrain_ompl_rrt():
     # planner.setupProblem3(start_pos, start_vel, home_pos, home_pos_radius)
     # planner_solution_path = Path()
     # planner.Solve(time_budget=1.0, path=planner_solution_path)
+
+    # solution path - og.PathGeometric
+    solution_path = planner._problem_setup.getSolutionPath()
+    state1 = solution_path.getState(0)
+    state2 = solution_path.getState(solution_path.getStateCount() - 1)
+    states = solution_path.getStates()
+    pos1 = TerrainOmplRrt.dubinsairplanePosition(state1)
+    yaw1 = TerrainOmplRrt.dubinsairplaneYaw(state1)
+    pos2 = TerrainOmplRrt.dubinsairplanePosition(state2)
+    yaw2 = TerrainOmplRrt.dubinsairplaneYaw(state2)
+    print(f"Planner solution path (og.PathGeometric)")
+    # print(type(solution_path))
+    print(f"path length: {solution_path.length():.2f}")
+    print(f"pos1: {pos1}, yaw1: {yaw1}")
+    print(f"pos2: {pos2}, yaw2: {yaw2}")
+
+    # plots
+    plot_path(start_pos, goal_pos, loiter_radius, candidate_path, states)
+
+
+def plot_path(start_pos, goal_pos, loiter_radius, path=None, states=None):
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    def plot_circle(ax, position, radius, label=""):
+        theta = np.arange(-math.pi, math.pi, 0.01 * math.pi)
+        x = position[0] + radius * np.cos(theta)
+        y = position[1] + radius * np.sin(theta)
+        z = position[2] * np.ones(len(theta))
+        ax.scatter(x, y, z, linestyle="solid", marker=".", s=1, c="blue")
+        ax.text(position[0] + 1.5 * radius, position[1], position[2], label)
+
+    def plot_path(ax, path):
+        position = path.position()
+        position = np.array(position)
+        x = position[:, 0]
+        y = position[:, 1]
+        z = position[:, 2]
+        ax.scatter(x, y, z, linestyle="solid", marker=".", s=1, c="green")
+
+    def plot_state(ax, state, label=""):
+        position = TerrainOmplRrt.dubinsairplanePosition(state)
+        yaw = TerrainOmplRrt.dubinsairplaneYaw(state)
+        x = position[0]
+        y = position[1]
+        z = position[2]
+        ax.scatter(x, y, z, marker="v", s=48, c="red")
+        ax.text(position[0], position[1], position[2], label)
+        print(position)
+
+    def plot_states(ax, states):
+        for i, state in enumerate(states):
+            plot_state(ax, state, f"state{i}")
+
+    # setup plot
+    ax = plt.figure().add_subplot(projection="3d")
+    ax.set_xlim(-400.0, 400.0)
+    ax.set_ylim(-400.0, 400.0)
+    # ax.set_zlim(0.0, 150.0)
+
+    # start circle
+    plot_circle(ax, start_pos, loiter_radius, "start")
+
+    # goal circle
+    plot_circle(ax, goal_pos, loiter_radius, "goal")
+
+    # path
+    if path is not None:
+        plot_path(ax, path)
+
+    # states
+    if states is not None:
+        plot_states(ax, states)
+
+    plt.show()
 
 
 def main():


### PR DESCRIPTION
Add matplotlib plots of the path and states when running the test case as a standalone script.

Added as a debugging diagnostic tool. As can be seen in the figure below the order of segments in the path is not correct.

![path_plot_v2](https://github.com/user-attachments/assets/4b2de60b-9c66-417c-bfa7-ad2515c38889)
