### PR TITLE
Add ubuntu-build CI workflow

### DIFF
--- a/.github/workflows/ccache.env
+++ b/.github/workflows/ccache.env
@@ -1,0 +1,10 @@
+# common ccache env vars for CI
+export CCACHE_SLOPPINESS=file_stat_matches
+
+mkdir -p ~/.ccache
+echo "base_dir = ${GITHUB_WORKSPACE}" > ~/.ccache/ccache.conf
+echo "compression = true" >> ~/.ccache/ccache.conf
+echo "compression_level = 6" >> ~/.ccache/ccache.conf
+echo "max_size = 400M" >> ~/.ccache/ccache.conf
+ccache -s
+ccache -z

--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -1,0 +1,128 @@
+name: ubuntu-build
+
+on: [push, pull_request, workflow_dispatch]
+
+concurrency:
+  group: ci-${{github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
+
+# permissions:
+#   contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    name: ubuntu-build
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Checkout pyplusplus
+        uses: actions/checkout@v4
+        with:
+          repository: ompl/pyplusplus.git
+          ref: main
+          path: pyplusplus
+
+      - name: Checkout ompl
+        uses: actions/checkout@v4
+        with:
+          repository: ompl/ompl.git
+          ref: main
+          path: ompl
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update && sudo apt-get install --no-install-recommends -y \
+          build-essential \
+          castxml \
+          ccache \
+          clang \
+          cmake \
+          doxygen \
+          git \
+          libflann-dev \
+          libeigen3-dev \
+          libboost-dev \
+          libboost-filesystem-dev \
+          libboost-numpy-dev \
+          libboost-program-options-dev \
+          libboost-python-dev \
+          libboost-serialization-dev \
+          libboost-test-dev \
+          libyaml-cpp-dev \
+          python3 \
+          python3-dev \
+          python3.12-venv
+
+      # - name: Set up Python ${{ matrix.python-version }}
+      #   uses: actions/setup-python@v3
+      #   with:
+      #     python-version: ${{ matrix.python-version }}
+
+      - name: Install Python dependencies
+        run: |
+          mkdir venv
+          python3 -m venv --system-site-packages venv
+          . venv/bin/activate
+          python3 -m pip install --upgrade pip
+          python3 -m pip install pygccxml
+          python3 -m pip install matplotlib
+          python3 -m pip install mavproxy
+          python3 -m pip install numpy
+          python3 -m pip install pymavlink
+          python3 -m pip install pytest
+
+      - name: Install pyplusplus
+        run: |
+          . venv/bin/activate
+          cd pyplusplus 
+          python3 -m pip install .
+
+      # Put ccache into github cache for faster build
+      - name: Prepare ccache timestamp
+        id: ccache_cache_timestamp
+        run: |
+          NOW=$(date -u +"%F-%T")
+          echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
+
+      - name: Cache files
+        uses: actions/cache@v3
+        with:
+          path: ~/.ccache
+          key: ${{github.workflow}}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}
+          restore-keys: ${{github.workflow}}-ccache-  # restore ccache from either previous build on this branch or on master
+
+      - name: Setup ccache
+        run: |
+          . .github/workflows/ccache.env
+
+      - name: Install ompl
+        run: |
+          . venv/bin/activate
+          mkdir -p ompl/build && cd ompl/build
+          cmake .. -DPYTHON_EXEC=$(which python3) -DOMPL_BUILD_PYBINDINGS=ON -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          make update_bindings
+          make ompl -j8
+          make py_ompl -j8
+          make all -j8
+          sudo make install
+
+      - name: Install terrain_nav_py
+        run: |
+          . venv/bin/activate
+          python3 -m pip install .
+          # pytest ./tests/test_dubins_airplane.py
+          pytest ./tests/test_dubins_path.py
+          # pytest ./tests/test_grid_map.py
+          pytest ./tests/test_ompl_setup.py
+          pytest ./tests/test_path.py
+          pytest ./tests/test_path_segment.py
+          # pytest ./tests/test_terrain_ompl_rrt.py
+          pytest ./tests/test_terrain_ompl.py
+          pytest ./tests/test_util.py
+

--- a/tests/test_dubins_airplane.py
+++ b/tests/test_dubins_airplane.py
@@ -28,6 +28,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import math
+import pytest
 
 from ompl import base as ob
 from ompl import geometric as og
@@ -45,9 +46,9 @@ def test_ompl_compound_state_space_states():
     # RealVectorStateInternal
     re3_s_ref = re3_s()
     # accessors
-    assert re3_s_ref[0] == 0.0
+    assert re3_s_ref[0] == pytest.approx(0.0)
     re3_s_ref[0] = 1.0
-    assert re3_s_ref[0] == 1.0
+    assert re3_s_ref[0] == pytest.approx(1.0)
 
     # SO(2) state space
     so2_space = ob.SO2StateSpace()
@@ -74,8 +75,8 @@ def test_ompl_compound_state_space_states():
     r_s = c_s_ref[0]
     s_s = c_s_ref[1]
 
-    assert r_s[0] == 0.0
-    assert s_s.value == 0.0
+    assert r_s[0] == pytest.approx(0.0)
+    assert s_s.value == pytest.approx(0.0)
 
 
 def test_dubins_airplane_state():
@@ -86,39 +87,39 @@ def test_dubins_airplane_state():
     c_space.lock()
 
     s = DubinsAirplaneStateSpace.DubinsAirplaneState(ob.State(c_space))
-    assert s.getX() == 0.0
-    assert s.getY() == 0.0
-    assert s.getZ() == 0.0
-    assert s.getYaw() == 0.0
+    assert s.getX() == pytest.approx(0.0)
+    assert s.getY() == pytest.approx(0.0)
+    assert s.getZ() == pytest.approx(0.0)
+    assert s.getYaw() == pytest.approx(0.0)
 
     s.setX(100.0)
     s.setY(200.0)
     s.setZ(50.0)
     s.setYaw(0.25 * math.pi)
-    assert s.getX() == 100.0
-    assert s.getY() == 200.0
-    assert s.getZ() == 50.0
-    assert s.getYaw() == 0.25 * math.pi
+    assert s.getX() == pytest.approx(100.0)
+    assert s.getY() == pytest.approx(200.0)
+    assert s.getZ() == pytest.approx(50.0)
+    assert s.getYaw() == pytest.approx(0.25 * math.pi)
 
     s.setXYZ(120.0, 210.0, 60.0)
-    assert s.getX() == 120.0
-    assert s.getY() == 210.0
-    assert s.getZ() == 60.0
+    assert s.getX() == pytest.approx(120.0)
+    assert s.getY() == pytest.approx(210.0)
+    assert s.getZ() == pytest.approx(60.0)
 
     s.setXYZYaw(150.0, 230.0, 45.0, 0.5 * math.pi)
-    assert s.getX() == 150.0
-    assert s.getY() == 230.0
-    assert s.getZ() == 45.0
-    assert s.getYaw() == 0.5 * math.pi
+    assert s.getX() == pytest.approx(150.0)
+    assert s.getY() == pytest.approx(230.0)
+    assert s.getZ() == pytest.approx(45.0)
+    assert s.getYaw() == pytest.approx(0.5 * math.pi)
 
     s.addToX(30.0)
-    assert s.getX() == 180.0
+    assert s.getX() == pytest.approx(180.0)
 
     s.addToY(35.0)
-    assert s.getY() == 265.0
+    assert s.getY() == pytest.approx(265.0)
 
     s.addToZ(-5.0)
-    assert s.getZ() == 40.0
+    assert s.getZ() == pytest.approx(40.0)
 
 
 def test_dubins_airplane_state_space():
@@ -132,10 +133,10 @@ def test_dubins_airplane_state_space():
 
     # max extent is pi for null R(3) x SO(2)
     e = da_space.getMaximumExtent()
-    assert e == math.pi
+    assert e == pytest.approx(math.pi)
 
     e = da_space.getEuclideanExtent()
-    assert e == 0.0
+    assert e == pytest.approx(0.0)
 
     # state1 = ob.State()
     # state2 = ob.State()


### PR DESCRIPTION
Add a CI workflow to build and test the package.

### Details

- Build ompl and py-ompl from source.
- Should use ccache to speed up comilation - may not be configured correctly.
- Do not test the main planner (`test_terrain_ompl_rrt`) as it will fail first time while waiting for the terrain cache to load.
