### PR TITLE
Fix approximate distance surface calculation 

### DIFF
--- a/src/terrain_nav_py/grid_map.py
+++ b/src/terrain_nav_py/grid_map.py
@@ -134,6 +134,18 @@ class GridMapSRTM(GridMap):
     """
     A GridMap using SRTM terrain data accessed using MAVProxy tools.
 
+    USGS EROS Archive - Digital Elevation - Shuttle Radar Topography Mission (SRTM) 1 Arc-Second Global
+    https://www.usgs.gov/centers/eros/science/usgs-eros-archive-digital-elevation-shuttle-radar-topography-mission-srtm-1
+
+    Projection	Geographic
+    Horizontal Datum	WGS84
+    Vertical Datum	EGM96 (Earth Gravitational Model 1996)
+    Vertical Units	Meters
+    Spatial Resolution	1 arc-second for global coverage (~30 meters)
+                        3 arc-seconds for global coverage (~90 meters)
+    Raster Size	1 degree tiles
+
+
     NOTE: the planner follows ROS conventions and must use ENU coordinates.
     """
 

--- a/src/terrain_nav_py/grid_map.py
+++ b/src/terrain_nav_py/grid_map.py
@@ -75,8 +75,8 @@ class GridMap:
         self._position = (0.0, 0.0)
         self._length = (1000.0, 1000.0)
         self._elevation = 0.0
-        self._distance_surface = 0.0
         self._max_elevation = 120.0
+        self._min_elevation = 50.0
         self._size = 10
 
     def __iter__(self) -> Iterator:
@@ -110,7 +110,7 @@ class GridMap:
         if layer == "elevation":
             return self._elevation
         elif layer == "distance_surface":
-            return self._distance_surface
+            return self._min_elevation
         elif layer == "max_elevation":
             return self._max_elevation
         else:
@@ -123,7 +123,7 @@ class GridMap:
         if layer == "elevation":
             return self._elevation
         elif layer == "distance_surface":
-            return self._distance_surface
+            return self._min_elevation
         elif layer == "max_elevation":
             return self._max_elevation
         else:
@@ -149,7 +149,7 @@ class GridMapSRTM(GridMap):
     NOTE: the planner follows ROS conventions and must use ENU coordinates.
     """
 
-    def __init__(self, map_lat, map_lon):
+    def __init__(self, map_lat, map_lon, max_elevation=120.0, min_elevation=50.0):
         super().__init__()
 
         self._map_lat = map_lat
@@ -169,8 +169,8 @@ class GridMapSRTM(GridMap):
 
         # set super class properties
         self._position = (0.0, 0.0)
-        self._distance_surface = 0.0
-        self._max_elevation = 120.0
+        self._max_elevation = max_elevation
+        self._min_elevation = min_elevation
 
         # ensure grid is updated
         self._updateGrid()
@@ -236,7 +236,7 @@ class GridMapSRTM(GridMap):
         if layer == "elevation":
             return alt
         elif layer == "distance_surface":
-            return alt + self._distance_surface
+            return alt + self._min_elevation
         elif layer == "max_elevation":
             return alt + self._max_elevation
         else:

--- a/tests/test_grid_map.py
+++ b/tests/test_grid_map.py
@@ -103,7 +103,11 @@ def test_grid_map_srtm():
         database=terrain_source, offline=terrain_offline
     )
 
-    grid_map = GridMapSRTM(map_lat, map_lon)
+    max_altitude = 120.0
+    min_altitude = 50.0
+    grid_map = GridMapSRTM(
+        map_lat, map_lon, max_elevation=max_altitude, min_elevation=min_altitude
+    )
 
     # check default grid extents
     assert grid_map.getLength()[0] == 10000
@@ -121,10 +125,10 @@ def test_grid_map_srtm():
     assert alt == expected_alt
 
     alt = grid_map.atPosition("distance_surface", position)
-    assert alt == expected_alt + 0.0
+    assert alt == expected_alt + min_altitude
 
     alt = grid_map.atPosition("max_elevation", position)
-    assert alt == expected_alt + 120.0
+    assert alt == expected_alt + max_altitude
 
     # terrain at index (use to find max and min over grid)
     assert grid_map.size() == (334) * (334)

--- a/tests/test_terrain_ompl.py
+++ b/tests/test_terrain_ompl.py
@@ -67,7 +67,7 @@ def test_terrain_ompl_gridmap_at_position():
     pos = (100.0, 100.0)
     assert map.atPosition("elevation", pos) == 0.0
     assert map.atPosition("max_elevation", pos) == 120.0
-    assert map.atPosition("distance_surface", pos) == 0.0
+    assert map.atPosition("distance_surface", pos) == 50.0
 
 
 def test_terrain_ompl_gridmap_iterator():
@@ -84,7 +84,7 @@ def test_terrain_ompl_gridmap_at():
     for index in map:
         assert map.atPosition("elevation", index) == 0.0
         assert map.atPosition("max_elevation", index) == 120.0
-        assert map.atPosition("distance_surface", index) == 0.0
+        assert map.atPosition("distance_surface", index) == 50.0
 
 
 def test_terrain_ompl_validity_checker_collision():


### PR DESCRIPTION
The `distance-surface` layer should be at least `min_elevation` above the terrain (`elevation`) layer.