### PR TITLE
Fix DubinsAirplaneStateSpace interpolation

### DIFF
--- a/src/terrain_nav_py/dubins_airplane.py
+++ b/src/terrain_nav_py/dubins_airplane.py
@@ -357,7 +357,7 @@ class DubinsAirplaneStateSpace(ob.CompoundStateSpace):
             return (
                 self._internal_state[0][0],
                 self._internal_state[0][1],
-                self._internal_state[0][2]
+                self._internal_state[0][2],
             )
 
         def getXYZYaw(self) -> tuple[float, float, float, float]:
@@ -368,7 +368,7 @@ class DubinsAirplaneStateSpace(ob.CompoundStateSpace):
                 self._internal_state[0][0],
                 self._internal_state[0][1],
                 self._internal_state[0][2],
-                self._internal_state[1].value
+                self._internal_state[1].value,
             )
 
         #   void setX(double x);
@@ -1908,7 +1908,7 @@ class DubinsAirplaneStateSpace(ob.CompoundStateSpace):
         alpha = mod2pi(th1 - th)
         beta = mod2pi(th2 - th)
 
-        # number of points to sample in SO(2) 
+        # number of points to sample in SO(2)
         num_step = 24
 
         L_desired2D = math.fabs(dz) * self._tanGammaMaxInv

--- a/src/terrain_nav_py/dubins_airplane.py
+++ b/src/terrain_nav_py/dubins_airplane.py
@@ -722,9 +722,10 @@ class DubinsAirplaneStateSpace(ob.CompoundStateSpace):
         return dp
 
     # virtual void interpolate(const ob::State* from, const ob::State* to, const double t, ob::State* state) const override;
-    def interpolate1(
-        self, from_state: ob.State, to_state: ob.State, t: float
-    ) -> ob.State:
+    # NOTE: overides base class interpolate - so cannot have different name...
+    def interpolate(
+        self, from_state: ob.State, to_state: ob.State, t: float, state: ob.State
+    ) -> None:
         """
         Calculates the state in between `from_state` and `to_state` after
         a fraction of `t` of the length of the path.
@@ -735,10 +736,27 @@ class DubinsAirplaneStateSpace(ob.CompoundStateSpace):
         :return: The interpolated state
         :rtype: ompl.base.State
         """
+        # print(f"[DubinsAirplaneStateSpace] interpolate")
+        # print(f"[DubinsAirplaneStateSpace] from_state: {DubinsAirplaneStateSpace.DubinsAirplaneState(from_state)}")
+        # print(f"[DubinsAirplaneStateSpace] to_state: {DubinsAirplaneStateSpace.DubinsAirplaneState(to_state)}")
+        # print(f"[DubinsAirplaneStateSpace] state: {DubinsAirplaneStateSpace.DubinsAirplaneState(state)}")
+
         # TODO: test
         firstTime = True
-        (_, _, state) = self.interpolate2(from_state, to_state, t, firstTime)
-        return state
+        path = DubinsPath()
+        segmentStarts = DubinsAirplaneStateSpace.SegmentStarts()
+        # state2 = ob.State(self)
+        # (_, _, state2) = self.interpolate2(from_state, to_state, t, firstTime, path, segmentStarts, state)
+        self.interpolate2(
+            from_state, to_state, t, firstTime, path, segmentStarts, state
+        )
+
+        # Copy
+        # da_state2 = DubinsAirplaneStateSpace.DubinsAirplaneState(state2)
+        da_state = DubinsAirplaneStateSpace.DubinsAirplaneState(state)
+        # (x, y, z, yaw) = da_state2.getXYZYaw()
+        # da_state.setXYZYaw(x, y, z, yaw)
+        # print(f"[DubinsAirplaneStateSpace] state: {da_state}")
 
     # virtual void interpolate(const ob::State* from, const ob::State* to, double t, bool& firstTime, DubinsPath& path,
     #                           SegmentStarts& segmentStarts, ob::State* state) const;
@@ -751,7 +769,8 @@ class DubinsAirplaneStateSpace(ob.CompoundStateSpace):
         path: DubinsPath,
         segmentStarts: SegmentStarts,
         state: ob.State,
-    ) -> tuple[DubinsPath, SegmentStarts, ob.State]:
+    ) -> None:
+        # ) -> tuple[DubinsPath, SegmentStarts, ob.State]:
         """
         Calculates the state in between from and to after a fraction of t of the length of the path.
 
@@ -795,13 +814,14 @@ class DubinsAirplaneStateSpace(ob.CompoundStateSpace):
         if math.isnan(path.length_3d()):
             state().setXYZ(sys.float_info.max, sys.float_info.max, sys.float_info.max)
         else:
-            state = self.interpolate3(path, segmentStarts, t)
+            self.interpolate3(path, segmentStarts, t, state)
 
-        return (path, segmentStarts, state)
+        # return (path, segmentStarts, state)
 
     def interpolate3(
-        self, path: DubinsPath, segmentStarts: SegmentStarts, t: float
-    ) -> ob.State:
+        self, path: DubinsPath, segmentStarts: SegmentStarts, t: float, state: ob.State
+    ) -> None:
+        # ) -> ob.State:
         """
         Calculates the state in between `from_state` and `to_state` after
         a fraction of `t` of the length of the known (non-optimal)
@@ -927,7 +947,7 @@ class DubinsAirplaneStateSpace(ob.CompoundStateSpace):
                             "This should never happen, otherwise something wrong in the DubinsAirplaneStateSpace.interpolate3"
                         )
 
-                state = ob.State(self)
+                # state = ob.State(self)
                 da_state = DubinsAirplaneStateSpace.DubinsAirplaneState(state)
                 da_state.setX(
                     da_interpol_state.getX() * self._rho
@@ -946,7 +966,8 @@ class DubinsAirplaneStateSpace(ob.CompoundStateSpace):
                 so2_space.enforceBounds(so2_state)
                 da_state.setYaw(da_interpol_state.getYaw())
                 interpol_seg = 0.0
-                return state
+                return
+                # return state
 
             else:
                 interpol_seg -= path.getSegmentLength(interpol_iter)

--- a/src/terrain_nav_py/terrain_ompl_rrt.py
+++ b/src/terrain_nav_py/terrain_ompl_rrt.py
@@ -648,6 +648,7 @@ class TerrainOmplRrt:
             )
 
             if debug_print:
+
                 def path_type_str(path_type):
                     msg = (
                         f"{dubins_path._type[0]}"
@@ -655,11 +656,21 @@ class TerrainOmplRrt:
                         f" {dubins_path._type[2]}"
                     )
                     return msg
+
                 print(f"[TerrainOmplRrt] dubins.idx:  {dubins_path.getIdx()}")
-                print(f"[TerrainOmplRrt] dubins.type: {path_type_str(dubins_path._type)}")
-                print(f"[TerrainOmplRrt] dubins.len:  {dubins_path._length[1]:.3f}       {dubins_path._length[3]:.3f}          {dubins_path._length[4]:.3f}")
+                print(
+                    f"[TerrainOmplRrt] dubins.type: {path_type_str(dubins_path._type)}"
+                )
+                print(
+                    f"[TerrainOmplRrt] dubins.len: "
+                    f"{dubins_path._length[1]:.3f} "
+                    f"{dubins_path._length[3]:.3f} "
+                    f"{dubins_path._length[4]:.3f} "
+                )
                 print(f"[TerrainOmplRrt] dubins.alt:  {dubins_path.getAltitudeCase()}")
-                print(f"[TerrainOmplRrt] dubins.cls:  {dubins_path.getClassification()}")
+                print(
+                    f"[TerrainOmplRrt] dubins.cls:  {dubins_path.getClassification()}"
+                )
                 print(f"[TerrainOmplRrt] dubins.ks:   {dubins_path._k_start}")
                 print(f"[TerrainOmplRrt] dubins.ke:   {dubins_path._k_end}")
 
@@ -669,7 +680,6 @@ class TerrainOmplRrt:
                 print(f"[TerrainOmplRrt] segs[3]:     {segmentStarts.segmentStarts[3]}")
                 print(f"[TerrainOmplRrt] segs[4]:     {segmentStarts.segmentStarts[4]}")
                 print(f"[TerrainOmplRrt] segs[5]:     {segmentStarts.segmentStarts[5]}")
-
 
             segment_start_state = ob.State(da_space)
             segment_end_state = ob.State(da_space)
@@ -711,7 +721,12 @@ class TerrainOmplRrt:
                     if total_length > 0.0:
                         # dt = resolution / total_length
                         num_step = int(total_length / resolution)
-                        t_samples = np.linspace(progress, progress + segment_progress, num_step, endpoint=False)
+                        t_samples = np.linspace(
+                            progress,
+                            progress + segment_progress,
+                            num_step,
+                            endpoint=False,
+                        )
                         for t in t_samples:
                             segment_state = path_segment.State()
                             state = da_space.interpolate3(dubins_path, segmentStarts, t)
@@ -730,7 +745,7 @@ class TerrainOmplRrt:
                             trajectory.append_state(segment_state)
                             track_progress = t
                     else:
-                            track_progress = progress
+                        track_progress = progress
 
                     # Append end state
                     if ((start_idx + 1) > (len(segmentStarts.segmentStarts) - 1)) or (

--- a/src/terrain_nav_py/terrain_ompl_rrt.py
+++ b/src/terrain_nav_py/terrain_ompl_rrt.py
@@ -716,6 +716,8 @@ class TerrainOmplRrt:
                     )
                     trajectory.flightpath_angle = dubins_path.getGamma()
 
+                    state = ob.State(da_space)
+
                     # handle case when start and end state are the same
                     track_progress = 0.0
                     if total_length > 0.0:
@@ -729,7 +731,8 @@ class TerrainOmplRrt:
                         )
                         for t in t_samples:
                             segment_state = path_segment.State()
-                            state = da_space.interpolate3(dubins_path, segmentStarts, t)
+                            # state = da_space.interpolate3(dubins_path, segmentStarts, t)
+                            da_space.interpolate3(dubins_path, segmentStarts, t, state)
 
                             position = TerrainOmplRrt.dubinsairplanePosition(state)
                             yaw = TerrainOmplRrt.dubinsairplaneYaw(state)


### PR DESCRIPTION
Ensure override of virtual `interpolate` method has correct name and signature.


## Details

The local planner was calling the default `interpolate` method on the base class `ob.StateSpace` rather than the derived method. The remaining overrides of `interpolate` retain different names to avoid conflicts.

The function signatures are changed to use pass-by-reference for modifying the interpolated state.
 