### PR TITLE
Validate start and goal positions and adjust planner resolution

### DIFF
--- a/src/terrain_nav_py/terrain_ompl_rrt.py
+++ b/src/terrain_nav_py/terrain_ompl_rrt.py
@@ -860,3 +860,31 @@ class TerrainOmplRrt:
         # TODO: test
         self._max_altitude = max_altitude
         self._min_altitude = min_altitude
+
+    @staticmethod
+    def validatePosition(
+        map: GridMap, centre_pos: tuple[float, float, float], radius: float
+    ) -> bool:
+        """
+        Check the position is not an inevitable collision state (ICS)
+
+        NOTE: this is an approximate the check whether the position
+              is a ICS.
+        """
+        # Map must have two layers: "distance_surface" and "max_elevation".
+        min_layer = "distance_surface"
+        max_layer = "max_elevation"
+        num_steps = 24
+        theta_samples = np.linspace(-math.pi, math.pi, num_steps)
+        pos_2d = np.array([centre_pos[0], centre_pos[1]])
+        pos_z = centre_pos[2]
+        points = [
+            pos_2d + radius * np.array((np.cos(theta), np.sin(theta)))
+            for theta in theta_samples
+        ]
+        for point in points:
+            min_z = map.atPosition(min_layer, point)
+            max_z = map.atPosition(max_layer, point)
+            if pos_z < min_z or pos_z > max_z:
+                return False
+        return True

--- a/tests/test_terrain_ompl_rrt.py
+++ b/tests/test_terrain_ompl_rrt.py
@@ -108,6 +108,7 @@ def test_terrain_ompl_rrt():
     max_altitude = 120.0
     min_altitude = 50.0
     time_budget = 10.0
+    resolution_m = 200.0
 
     # create map
     grid_map = GridMapSRTM(map_lat=map_lat, map_lon=map_lon)
@@ -153,6 +154,16 @@ def test_terrain_ompl_rrt():
     # PLANNER_MODE.GLOBAL
     # set up problem from start and goal positions and start loiter radius
     planner_mgr.setupProblem2(start_pos, goal_pos, turning_radius)
+
+    # Adjust validity checking resolution as needed. This is expressed as
+    # a fraction of the spaces extent.
+    problem = planner_mgr.getProblemSetup()
+    resolution_requested = resolution_m / grid_length
+    problem.setStateValidityCheckingResolution(resolution_requested)
+    si = problem.getSpaceInformation()
+    resolution_used = si.getStateValidityCheckingResolution()
+    print(f"Resolution used: {resolution_used}")
+
     candidate_path = Path()
     planner_mgr.Solve1(time_budget=time_budget, path=candidate_path)
 

--- a/tests/test_terrain_ompl_rrt.py
+++ b/tests/test_terrain_ompl_rrt.py
@@ -58,20 +58,22 @@ def test_terrain_ompl_rrt():
     # Buckingham Picnic Area, Colorado
     goal_lat = 40.11188249790071
     goal_lon = -105.30681932208977
+    grid_length_factor = 1.2
 
     # Ward, Colorado
-    goal_lat = 40.072504162423655
-    goal_lon = -105.50885876436985
+    # goal_lat = 40.072504162423655
+    # goal_lon = -105.50885876436985
 
     # Colorado Mountain Ranch, Colorado
-    goal_lat = 40.061037962756885
-    goal_lon = -105.41560711209344
+    # goal_lat = 40.061037962756885
+    # goal_lon = -105.41560711209344
 
     # Davos
-    start_lat = 46.8141348
-    start_lon = 9.8488310
-    goal_lat = 46.8201124
-    goal_lon = 9.8260916
+    # start_lat = 46.8141348
+    # start_lon = 9.8488310
+    # goal_lat = 46.8201124
+    # goal_lon = 9.8260916
+    # grid_length_factor = 5.0
 
     distance = mp_util.gps_distance(start_lat, start_lon, goal_lat, goal_lon)
     bearing_deg = mp_util.gps_bearing(start_lat, start_lon, goal_lat, goal_lon)
@@ -88,7 +90,6 @@ def test_terrain_ompl_rrt():
     (map_lat, map_lon) = mp_util.gps_offset(
         start_lat, start_lon, 0.5 * east, 0.5 * north
     )
-    grid_length_factor = 5.0
     grid_length = grid_length_factor * max(math.fabs(east), math.fabs(north))
     print(f"grid_length:    {grid_length:.0f} m")
 
@@ -108,7 +109,7 @@ def test_terrain_ompl_rrt():
     climb_angle_rad = 0.15
     max_altitude = 120.0
     min_altitude = 50.0
-    time_budget = 10.0
+    time_budget = 20.0
     resolution_m = 200.0
 
     # create map
@@ -193,6 +194,27 @@ def test_terrain_ompl_rrt():
             f"[{x:.2f}, {y:.2f}, {z:.2f}]; "
             f"ter_alt: {elevation:.2f}, agl_alt: {(z - elevation):.2f}"
         )
+
+    # More information... from og.SimpleSetup
+    problem = planner_mgr.getProblemSetup()
+
+    problem.getGoal()
+    last_comp_time = problem.getLastPlanComputationTime()
+    status = problem.getLastPlannerStatus()
+    last_simp_time = problem.getLastSimplificationTime()
+    oo = problem.getOptimizationObjective()
+    planner = problem.getPlanner()
+    problem_definition = problem.getProblemDefinition()
+    solution_path = problem.getSolutionPath()
+    planner_name = problem.getSolutionPlannerName()
+    si = problem.getSpaceInformation()
+    vc = problem.getStateValidityChecker()
+
+    planner_data = ob.PlannerData(si)
+    problem.getPlannerData(planner_data)
+    print(planner_data)
+    print(f"numVertices: {planner_data.numVertices()}")
+    print(f"numEdges: {planner_data.numEdges()}")
 
     # only display plots if run as script
     if __name__ == "__main__":

--- a/tests/test_terrain_ompl_rrt.py
+++ b/tests/test_terrain_ompl_rrt.py
@@ -116,17 +116,18 @@ def test_terrain_ompl_rrt():
     terrain_map = TerrainMap()
     terrain_map.setGridMap(grid_map)
 
-    # create planner
-    da_space = DubinsAirplaneStateSpace(turningRadius=turning_radius, gam=climb_angle_rad)
-    planner = TerrainOmplRrt(da_space)
-    planner.setMap(terrain_map)
-    planner.setAltitudeLimits(max_altitude=max_altitude, min_altitude=min_altitude)
-    planner.setBoundsFromMap(terrain_map.getGridMap())
+    # create planner manager
+    da_space = DubinsAirplaneStateSpace(
+        turningRadius=turning_radius, gam=climb_angle_rad
+    )
+    planner_mgr = TerrainOmplRrt(da_space)
+    planner_mgr.setMap(terrain_map)
+    planner_mgr.setAltitudeLimits(max_altitude=max_altitude, min_altitude=min_altitude)
+    planner_mgr.setBoundsFromMap(terrain_map.getGridMap())
 
     # set start and goal positions
     start_pos = [start_east, start_north, loiter_alt]
     goal_pos = [goal_east, goal_north, loiter_alt]
-
 
     # adjust the start and goal altitudes
     start_pos[2] += grid_map.atPosition("elevation", start_pos)
@@ -141,24 +142,24 @@ def test_terrain_ompl_rrt():
 
     # PLANNER_MODE.GLOBAL
     # set up problem from start and goal positions and start loiter radius
-    planner.setupProblem2(start_pos, goal_pos, turning_radius)
+    planner_mgr.setupProblem2(start_pos, goal_pos, turning_radius)
     candidate_path = Path()
-    planner.Solve1(time_budget=time_budget, path=candidate_path)
+    planner_mgr.Solve1(time_budget=time_budget, path=candidate_path)
 
     # PLANNER_MODE.EMERGENCY_ABORT
     # set up problem start position and velocity and rally points
-    # planner.setupProblem4(start_pos, start_vel, rally_points)
-    # planner_solution_path = Path()
-    # planner.Solve(time_budget=1.0, path=planner_solution_path)
+    # planner_mgr.setupProblem4(start_pos, start_vel, rally_points)
+    # planner_mgr_solution_path = Path()
+    # planner_mgr.Solve(time_budget=1.0, path=planner_solution_path)
 
     # PLANNER_MODE.RETURN
     # set up problem start position and velocity and home position and radius
-    # planner.setupProblem3(start_pos, start_vel, home_pos, home_pos_radius)
-    # planner_solution_path = Path()
-    # planner.Solve(time_budget=1.0, path=planner_solution_path)
+    # planner_mgr.setupProblem3(start_pos, start_vel, home_pos, home_pos_radius)
+    # planner_mgr_solution_path = Path()
+    # planner_mgr.Solve(time_budget=1.0, path=planner_solution_path)
 
     # check states are all above the min_altitude
-    solution_path = planner._problem_setup.getSolutionPath()
+    solution_path = planner_mgr._problem_setup.getSolutionPath()
     states = solution_path.getStates()
     for state in states:
         da_state = DubinsAirplaneStateSpace.DubinsAirplaneState(state)
@@ -203,12 +204,12 @@ def test_terrain_ompl_rrt_solution_path_to_path():
     terrain_map = TerrainMap()
     terrain_map.setGridMap(grid_map)
 
-    # create planner
+    # create planner manager
     da_space = DubinsAirplaneStateSpace(turningRadius=loiter_radius, gam=gamma)
-    planner = TerrainOmplRrt(da_space)
-    planner.setMap(terrain_map)
-    planner.setAltitudeLimits(max_altitude, min_altitude)
-    planner.setBoundsFromMap(terrain_map.getGridMap())
+    planner_mgr = TerrainOmplRrt(da_space)
+    planner_mgr.setMap(terrain_map)
+    planner_mgr.setAltitudeLimits(max_altitude, min_altitude)
+    planner_mgr.setBoundsFromMap(terrain_map.getGridMap())
 
     # set start and goal
     start_pos = [0.0, 0.0, 60.0]
@@ -219,10 +220,10 @@ def test_terrain_ompl_rrt_solution_path_to_path():
     goal_pos[2] += grid_map.atPosition("elevation", goal_pos)
 
     # set up problem from start and goal positions and start loiter radius
-    planner.setupProblem2(start_pos, goal_pos, loiter_radius)
+    planner_mgr.setupProblem2(start_pos, goal_pos, loiter_radius)
 
     # initialise an empty solution path
-    problem = planner.getProblemSetup()
+    problem = planner_mgr.getProblemSetup()
     si = problem.getSpaceInformation()
     solution_path = og.PathGeometric(si)
 
@@ -238,7 +239,7 @@ def test_terrain_ompl_rrt_solution_path_to_path():
     solution_path.append(state())
 
     trajectory_segments = Path()
-    planner.solutionPathToPath(solution_path, trajectory_segments)
+    planner_mgr.solutionPathToPath(solution_path, trajectory_segments)
 
     states = solution_path.getStates()
 

--- a/tests/test_terrain_ompl_rrt.py
+++ b/tests/test_terrain_ompl_rrt.py
@@ -88,7 +88,8 @@ def test_terrain_ompl_rrt():
     (map_lat, map_lon) = mp_util.gps_offset(
         start_lat, start_lon, 0.5 * east, 0.5 * north
     )
-    grid_length = 1.2 * max(math.fabs(east), math.fabs(north))
+    grid_length_factor = 5.0
+    grid_length = grid_length_factor * max(math.fabs(east), math.fabs(north))
     print(f"grid_length:    {grid_length:.0f} m")
 
     start_east = -0.5 * east

--- a/tests/test_terrain_ompl_rrt.py
+++ b/tests/test_terrain_ompl_rrt.py
@@ -136,6 +136,16 @@ def test_terrain_ompl_rrt():
     # TODO: check the start and goal states are valid. This requires a
     #       correctly calculated distance surface: a surface where at each
     # point a circle of radius r will not intersect with the elevation layer.
+    is_start_valid = planner_mgr.validatePosition(grid_map, start_pos, loiter_radius)
+    if not is_start_valid:
+        print(f"Invalid start position: {start_pos}")
+    else:
+        print(f"Accept start position: {start_pos}")
+    is_goal_valid = planner_mgr.validatePosition(grid_map, start_pos, loiter_radius)
+    if not is_goal_valid:
+        print(f"Invalid goal position: {goal_pos}")
+    else:
+        print(f"Accept goal position: {start_pos}")
 
     # NOTE: if the time budget is insufficient, the solution tree may not
     #       include a goal state, and an approximate solution will be found.


### PR DESCRIPTION
Following #37, add checks to ensure the start and goal loiter circles are valid, and allow the local planner resolution to be updated to help performance.

## Details

- Add method to verify a circle at a position is valid.
- Check start and goal states.
- Allow the local planner resolution to be set (rather than use the default of 0.001 set in the problem setup).
- Add variable to scale the map length.
- Add some additional debug info (retrieve planner data etc.)  