### PR TITLE
Use correct state types in path segment and fix length calculation

### DIFF
--- a/src/terrain_nav_py/path_segment.py
+++ b/src/terrain_nav_py/path_segment.py
@@ -394,9 +394,11 @@ class PathSegment:
             start_vector = (segment_start_2d - arc_center_2d).normalized()
             end_vector = (segment_end_2d - arc_center_2d).normalized()
 
-            psi = math.atan2(end_vector.y, end_vector.x) - math.atan2(
-                start_vector.y, start_vector.x
-            )
+            # get directed angle between two vectors
+            psi_s = math.atan2(start_vector.y, start_vector.x)
+            psi_e = math.atan2(end_vector.y, end_vector.x)
+            dir = (start_vector % segment_start_tangent_2d).normalized().z
+            psi = dir * (psi_e - psi_s)
             psi = wrap_2pi(psi)
             length = radius * psi
 

--- a/src/terrain_nav_py/terrain_ompl_rrt.py
+++ b/src/terrain_nav_py/terrain_ompl_rrt.py
@@ -45,6 +45,9 @@ import numpy as np
 from ompl import base as ob
 from ompl import geometric as og
 
+from pymavlink.quaternion import Quaternion
+from pymavlink.rotmat import Vector3
+
 from terrain_nav_py.dubins_airplane import DubinsAirplaneStateSpace
 from terrain_nav_py.dubins_path import DubinsPath
 
@@ -737,14 +740,13 @@ class TerrainOmplRrt:
                             position = TerrainOmplRrt.dubinsairplanePosition(state)
                             yaw = TerrainOmplRrt.dubinsairplaneYaw(state)
                             velocity = (math.cos(yaw), math.sin(yaw), 0.0)
-                            segment_state.position = position
-                            segment_state.velocity = velocity
-                            segment_state.attitude = (
-                                math.cos(yaw / 2.0),
-                                0.0,
-                                0.0,
-                                math.sin(yaw / 2.0),
+                            segment_state.position = Vector3(
+                                position[0], position[1], position[2]
                             )
+                            segment_state.velocity = Vector3(
+                                velocity[0], velocity[1], velocity[2]
+                            )
+                            segment_state.attitude = Quaternion([0.0, 0.0, yaw])
                             trajectory.append_state(segment_state)
                             track_progress = t
                     else:
@@ -762,14 +764,13 @@ class TerrainOmplRrt:
                         )
                         end_yaw = TerrainOmplRrt.dubinsairplaneYaw(segment_end_state)
                         end_velocity = (math.cos(end_yaw), math.sin(end_yaw), 0.0)
-                        end_state.position = end_position
-                        end_state.velocity = end_velocity
-                        end_state.attitude = (
-                            math.cos(end_yaw / 2.0),
-                            0.0,
-                            0.0,
-                            math.sin(end_yaw / 2.0),
+                        end_state.position = Vector3(
+                            end_position[0], end_position[1], end_position[2]
                         )
+                        end_state.velocity = Vector3(
+                            end_velocity[0], end_velocity[1], end_velocity[2]
+                        )
+                        end_state.attitude = [0.0, 0.0, end_yaw]
                         trajectory.append_state(end_state)
 
                     progress = track_progress

--- a/tests/test_path_segment.py
+++ b/tests/test_path_segment.py
@@ -36,6 +36,7 @@ from pymavlink.rotmat import Vector3
 
 from terrain_nav_py.path_segment import State
 from terrain_nav_py.path_segment import PathSegment
+from terrain_nav_py.util import wrap_2pi
 
 FLOAT_EPS = 1.0e-6
 
@@ -605,8 +606,70 @@ def test_path_segment_get_line_progress2():
     assert theta == 1.0
 
 
+def test_path_segment_get_length_angle_calc():
+    t = Vector3(0, 1, 0)
+    a = Vector3(1, 0, 0)
+    b = Vector3(0, 1, 0)
+    dir = (a % t).normalized().z
+    psi_a = math.atan2(a.y, a.x)
+    psi_b = math.atan2(b.y, b.x)
+    psi_ab = dir * (psi_b - psi_a)
+    psi_ab = wrap_2pi(psi_ab)
+    print(f"dir: {dir:.1f}, psi: {math.degrees(psi_ab):.1f}")
+
+    t = Vector3(0, 1, 0)
+    a = Vector3(1, 0, 0)
+    b = Vector3(-1, 0, 0)
+    dir = (a % t).normalized().z
+    psi_a = math.atan2(a.y, a.x)
+    psi_b = math.atan2(b.y, b.x)
+    psi_ab = dir * (psi_b - psi_a)
+    psi_ab = wrap_2pi(psi_ab)
+    print(f"dir: {dir:.1f}, psi: {math.degrees(psi_ab):.1f}")
+
+    t = Vector3(0, 1, 0)
+    a = Vector3(1, 0, 0)
+    b = Vector3(0, -1, 0)
+    dir = (a % t).normalized().z
+    psi_a = math.atan2(a.y, a.x)
+    psi_b = math.atan2(b.y, b.x)
+    psi_ab = dir * (psi_b - psi_a)
+    psi_ab = wrap_2pi(psi_ab)
+    print(f"dir: {dir:.1f}, psi: {math.degrees(psi_ab):.1f}")
+
+    t = Vector3(0, 1, 0)
+    a = Vector3(-1, 0, 0)
+    b = Vector3(0, 1, 0)
+    dir = (a % t).normalized().z
+    psi_a = math.atan2(a.y, a.x)
+    psi_b = math.atan2(b.y, b.x)
+    psi_ab = dir * (psi_b - psi_a)
+    psi_ab = wrap_2pi(psi_ab)
+    print(f"dir: {dir:.1f}, psi: {math.degrees(psi_ab):.1f}")
+
+    t = Vector3(0, 1, 0)
+    a = Vector3(-1, 0, 0)
+    b = Vector3(0, -1, 0)
+    dir = (a % t).normalized().z
+    psi_a = math.atan2(a.y, a.x)
+    psi_b = math.atan2(b.y, b.x)
+    psi_ab = dir * (psi_b - psi_a)
+    psi_ab = wrap_2pi(psi_ab)
+    print(f"dir: {dir:.1f}, psi: {math.degrees(psi_ab):.1f}")
+
+    t = Vector3(0, -1, 0)
+    a = Vector3(-1, 0, 0)
+    b = Vector3(0, 1, 0)
+    dir = (a % t).normalized().z
+    psi_a = math.atan2(a.y, a.x)
+    psi_b = math.atan2(b.y, b.x)
+    psi_ab = dir * (psi_b - psi_a)
+    psi_ab = wrap_2pi(psi_ab)
+    print(f"dir: {dir:.1f}, psi: {math.degrees(psi_ab):.1f}")
+
+
 def main():
-    test_path_segment_get_arc_progress2()
+    test_path_segment_get_length_angle_calc()
 
 
 if __name__ == "__main__":

--- a/tests/test_terrain_ompl_rrt.py
+++ b/tests/test_terrain_ompl_rrt.py
@@ -314,9 +314,9 @@ def plot_path(
         # check the state vector is not empty
         if position.size == 0:
             return
-        x = position[:, 0]
-        y = position[:, 1]
-        z = position[:, 2]
+        x = np.array([p.x for p in position])
+        y = np.array([p.y for p in position])
+        z = np.array([p.z for p in position])
         ax.scatter(x, y, z, linestyle="solid", marker=".", s=1, c="green")
 
         # plot velocity vectors along the path
@@ -328,9 +328,9 @@ def plot_path(
 
         scale = 0.25 * loiter_radius
         stride = 10
-        vx = velocity[:, 0]
-        vy = velocity[:, 1]
-        vz = velocity[:, 2]
+        vx = np.array([v.x for v in velocity])
+        vy = np.array([v.y for v in velocity])
+        vz = np.array([v.z for v in velocity])
         u = scale * vx
         v = scale * vy
         w = scale * vz


### PR DESCRIPTION
Use correct vector type when populating PathSegments, and fix arc length calculation.

## Details

- Use the correct Vector3 type when populating state in PathSegment.
- Fix path segment length calculation, accounting for the path direction.