### PR TITLE
Add exclusion polygon fences

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "pymavlink>=2.4",
   "pytest>=8.3",
   "scipy>=1.15",
+  "shapely>=2.0",
 ]
 
 [project.urls]

--- a/src/terrain_nav_py/ompl_setup.py
+++ b/src/terrain_nav_py/ompl_setup.py
@@ -85,6 +85,8 @@ class OmplSetup(og.SimpleSetup):
     def __init__(self, state_space):
         super().__init__(state_space)
 
+        self._terrain_validity_checker = None
+
     def setDefaultObjective(self) -> None:
         """
         Set the default objective
@@ -146,7 +148,13 @@ class OmplSetup(og.SimpleSetup):
         :param check_max_altitude: set true to check maximum altitude
         :type check_max_altitude: bool
         """
-        validity_checker = TerrainValidityChecker(
+        self._terrain_validity_checker = TerrainValidityChecker(
             self.getSpaceInformation(), map, check_max_altitude
         )
-        self.setStateValidityChecker(validity_checker)
+        self.setStateValidityChecker(self._terrain_validity_checker)
+
+    def setExclusionPolygons(
+        self, exclusion_polygons: list[list[tuple[float, float]]]
+    ) -> None:
+        # TODO: test
+        self._terrain_validity_checker.setExclusionPolygons(exclusion_polygons)

--- a/tests/test_terrain_ompl.py
+++ b/tests/test_terrain_ompl.py
@@ -174,5 +174,38 @@ def test_terrain_ompl_sampler_uniform():
     assert da_state.getYaw() != 0.0
 
 
+# inclusion tests
+def test_polygon_inclusion_checker():
+    from shapely import geometry
+
+    polygon = [
+        (100, 100),
+        (50, 100),
+        (50, 50),
+        (100, 50),
+    ]
+    line = geometry.LineString(polygon)
+    polygon = geometry.Polygon(line)
+
+    point = geometry.Point(75, 75)
+    assert polygon.contains(point) == True
+
+    point = geometry.Point(0, 0)
+    assert polygon.contains(point) == False
+
+    point = geometry.Point(50, 50)
+    assert polygon.contains(point) == False
+    assert polygon.boundary.contains(point) == True
+
+    point = geometry.Point(50, 75)
+    assert polygon.contains(point) == False
+    assert polygon.boundary.contains(point) == True
+
+    point = geometry.Point(100, 75)
+    assert polygon.contains(point) == False
+    assert polygon.boundary.contains(point) == True
+
+
+
 if __name__ == "__main__":
     test_terrain_ompl_gridmap_iterator()


### PR DESCRIPTION
Add support for planning around exclusion polygon fences.

## Details

- Add a dependency on `shapely` which is used for collision checks.
- Add an exclusion fence check in the state validity checker. Points on the boundary are considered to be in collision. 

<img width="400" alt="exclusion_polys_v1" src="https://github.com/user-attachments/assets/538dd646-36d8-4f15-b19f-263e5ab6f741" />

<img width="400" alt="exclusion_polys_v2" src="https://github.com/user-attachments/assets/c2af349c-85a2-492f-941f-67c4a242d77c" />
